### PR TITLE
fix: pass CLIENT_FOUND_ROWS

### DIFF
--- a/src/opts.rs
+++ b/src/opts.rs
@@ -698,7 +698,8 @@ impl Opts {
             | CapabilityFlags::CLIENT_MULTI_RESULTS
             | CapabilityFlags::CLIENT_PS_MULTI_RESULTS
             | CapabilityFlags::CLIENT_DEPRECATE_EOF
-            | CapabilityFlags::CLIENT_PLUGIN_AUTH;
+            | CapabilityFlags::CLIENT_PLUGIN_AUTH
+            | CapabilityFlags::CLIENT_FOUND_ROWS;
 
         if self.inner.mysql_opts.db_name.is_some() {
             out |= CapabilityFlags::CLIENT_CONNECT_WITH_DB;


### PR DESCRIPTION
This changes the behaviour of the affected count returned for mutations (UPDATE/INSERT etc). It makes MySQL return the FOUND rows instead of the AFFECTED rows. Without this, MySQL returns 0 affected row when performing a noop update. This breaks the QueryEngine when performing nested connects which expect the update to have had happened.

You can read more about it here https://dev.mysql.com/doc/refman/8.0/en/information-functions.html.

<img width="1123" alt="image" src="https://user-images.githubusercontent.com/25233379/217286942-9048580b-f333-4db2-a6a6-d2d9b0180a9c.png">