### PR TITLE
fix: mariadb 11.x version detection

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ tracing = { version = "0.1.37", default-features = false, features = ["attribute
 twox-hash = "1"
 url = "2.1"
 regex = "1.10.3"
+lexical = "6.1.0"
 
 [dependencies.tokio-rustls]
 version = "0.23.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ tokio-util = { version = "0.7.2", features = ["codec", "io"] }
 tracing = { version = "0.1.37", default-features = false, features = ["attributes"], optional = true }
 twox-hash = "1"
 url = "2.1"
+regex = "1.10.3"
 
 [dependencies.tokio-rustls]
 version = "0.23.4"

--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -55,6 +55,11 @@ pub mod pool;
 pub mod routines;
 pub mod stmt_cache;
 
+lazy_static::lazy_static! {
+    static ref FIXED_MARIADB_VERSION_RE: Regex =
+        Regex::new(r"^(?:5.5.5-)?(\d{1,2})\.(\d{1,2})\.(\d{1,3})-MariaDB").unwrap();
+}
+
 /// Helper that asynchronously disconnects the givent connection on the default tokio executor.
 fn disconnect(mut conn: Conn) {
     let disconnected = conn.inner.disconnected;
@@ -469,14 +474,14 @@ impl Conn {
         };
 
         self.inner.capabilities = handshake.capabilities() & self.inner.opts.get_capabilities();
-        self.inner.version = handshake
-            .maria_db_server_version_parsed()
-            .map(|version| {
-                self.inner.is_mariadb = true;
-                version
-            })
-            .or_else(|| handshake.server_version_parsed())
-            .unwrap_or((0, 0, 0));
+        self.inner.version =
+            Self::fixed_maria_db_server_version_parsed(handshake.server_version_ref())
+                .map(|version| {
+                    self.inner.is_mariadb = true;
+                    version
+                })
+                .or_else(|| handshake.server_version_parsed())
+                .unwrap_or((0, 0, 0));
         self.inner.id = handshake.connection_id();
         self.inner.status = handshake.status_flags();
         self.inner.auth_plugin = match handshake.auth_plugin() {
@@ -491,6 +496,20 @@ impl Conn {
             None => AuthPlugin::MysqlNativePassword,
         };
         Ok(())
+    }
+
+    /// Parsed mariadb server version.
+    /// Fixed version of `Handshake::maria_db_server_version_parsed` (only present on Prisma's fork).
+    /// See https://github.com/blackbeam/rust_mysql_common/issues/124 for more info.
+    pub fn fixed_maria_db_server_version_parsed(version: &[u8]) -> Option<(u16, u16, u16)> {
+        FIXED_MARIADB_VERSION_RE.captures(version).map(|captures| {
+            // Should not panic because validated with regex
+            (
+                parse::<u16, _>(captures.get(1).unwrap().as_bytes()).unwrap(),
+                parse::<u16, _>(captures.get(2).unwrap().as_bytes()).unwrap(),
+                parse::<u16, _>(captures.get(3).unwrap().as_bytes()).unwrap(),
+            )
+        })
     }
 
     async fn switch_to_ssl_if_needed(&mut self) -> Result<()> {

--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -50,6 +50,8 @@ use crate::{
 
 use self::routines::Routine;
 
+use regex::Regex;
+
 pub mod binlog_stream;
 pub mod pool;
 pub mod routines;

--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -507,9 +507,9 @@ impl Conn {
         FIXED_MARIADB_VERSION_RE.captures(version).map(|captures| {
             // Should not panic because validated with regex
             (
-                captures.get(1).unwrap().as_str().parse().unwrap(),
-                captures.get(2).unwrap().as_str().parse().unwrap(),
-                captures.get(3).unwrap().as_str().parse().unwrap(),
+                lexical::parse::<u16, _>(captures.get(1).unwrap().as_bytes()).unwrap(),
+                lexical::parse::<u16, _>(captures.get(2).unwrap().as_bytes()).unwrap(),
+                lexical::parse::<u16, _>(captures.get(3).unwrap().as_bytes()).unwrap(),
             )
         })
     }

--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -50,7 +50,7 @@ use crate::{
 
 use self::routines::Routine;
 
-use regex::Regex;
+use regex::bytes::Regex;
 
 pub mod binlog_stream;
 pub mod pool;

--- a/src/conn/mod.rs
+++ b/src/conn/mod.rs
@@ -505,9 +505,9 @@ impl Conn {
         FIXED_MARIADB_VERSION_RE.captures(version).map(|captures| {
             // Should not panic because validated with regex
             (
-                parse::<u16, _>(captures.get(1).unwrap().as_bytes()).unwrap(),
-                parse::<u16, _>(captures.get(2).unwrap().as_bytes()).unwrap(),
-                parse::<u16, _>(captures.get(3).unwrap().as_bytes()).unwrap(),
+                captures.get(1).unwrap().as_str().parse().unwrap(),
+                captures.get(2).unwrap().as_str().parse().unwrap(),
+                captures.get(3).unwrap().as_str().parse().unwrap(),
             )
         })
     }


### PR DESCRIPTION
## Overview

This work is needed for https://github.com/prisma/prisma-engines/pull/4704

See https://github.com/blackbeam/rust_mysql_common/issues/124 for more info about the fix itself.

This PR is an implementation of the proposed fix in the `mysql_common` issue above 👆. The actual issue lives in `mysql_common`. Since we have a fork that's far behind, this is a temporary fix until:
1. The actual issue is fixed
2. We get our fork on-par with the upstream again